### PR TITLE
Clip long lines.

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,10 @@ module.exports = function(opts) {
                       + ': ' + l.value, cols);
         });
 
+      rows = rows.map(function(line) {
+         return line.substring(0,cols);
+      });
+
       var addPaddingTop = function(padding) {
         while (padding--) rows.unshift(emptyLine);
       };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,18 @@
+var playerui = require('./index');
+
+// Initialize UI object
+var ui = playerui();
+
+// add some labels
+ui.setLabel('source', 'Source', 'Chariot - Someday, in the Event That Mankind Actually Figures Out What it is That This World Revolves Around, Thousands of People are Going to Be Shocked and Perplexed to Find Out it Was Not Them. Sometimes, This Includes Me.');
+ui.setLabel('state', 'Playing', 'Playing...');
+ui.setLabel('position', 'Position', '10:00 / 50:00');
+
+// specify which labels to show
+ui.showLabels('source', 'state', 'position');
+
+// set progress bar to 20%
+ui.setProgress(20);
+
+// output
+ui.render();


### PR DESCRIPTION
Previously, lines which were longer than the number of column in the terminal caused the display to become all wonky.

Also, added a test script (which is just copied from the README.md).